### PR TITLE
Removed trailing slash in API calls

### DIFF
--- a/src/app/quiz/quiz.component.ts
+++ b/src/app/quiz/quiz.component.ts
@@ -29,6 +29,9 @@ export class QuizComponent implements OnInit {
     var loc = window.location.href;
     var tmp = loc.split(":");
     var url = tmp.slice(0,2).join(":");
+    if(tmp.length == 2){
+      url = url.slice(0, -1); // remove trailing "/"; otherwise calls ".com/:8080/api"
+    }
     this.gameService.url = url;
 
     this.gameService.getQuiz(this.level).subscribe(


### PR DESCRIPTION
When an API got called it called something like `ip.com/:8080/api/...` which failed because the port wasn't assigned properly.

This PR removes that trailing slash.