### PR TITLE
Removed hammerjs script to fix building problem

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -31,7 +31,7 @@
               "src/styles.sass"
             ],
             "scripts": [
-              "./node_modules/hammerjs/hammer.min.js"
+              
             ]
           },
           "configurations": {


### PR DESCRIPTION
`ng build` fails, the fix seems to be to remove a script from `angular.json` file