### PR TITLE
Fix leaderboard not showing

### DIFF
--- a/src/app/leaderboard/leaderboard.component.html
+++ b/src/app/leaderboard/leaderboard.component.html
@@ -1,4 +1,4 @@
-<div class="wrapper" *ngIf="!leaderboardEmpty">
+<div class="wrapper">
   <form class="submitLeader" #leaderForm="ngForm" (ngSubmit)="onSubmit()" *ngIf="!submitted && gameover">
     <div class="form-group">
       <label for="name">Username: </label>

--- a/src/app/leaderboard/leaderboard.component.ts
+++ b/src/app/leaderboard/leaderboard.component.ts
@@ -35,6 +35,9 @@ export class LeaderboardComponent implements OnInit {
     var loc = window.location.href;
     var tmp = loc.split(":");
     var url = tmp.slice(0,2).join(":");
+    if(tmp.length == 2){
+      url = url.slice(0, -1); // remove trailing "/"; otherwise calls ".com/:8080/api"
+    }
     this.userService.url = url;
     
     this.userService.getScores().subscribe(


### PR DESCRIPTION
Removed the HTML condition for not showing leaderboard if it is empty that had a problem because the score submit was not showing either. The also the calls to the service were not working because of trailing slash not being removed.